### PR TITLE
Ensure body exists for group chat message

### DIFF
--- a/lib/manage.js
+++ b/lib/manage.js
@@ -148,7 +148,7 @@ export async function manage({meeting, meetings, xmppOptions}) {
       }
 
       // group chat message
-      if(stanza.attrs.type === 'groupchat') {
+      if(stanza.attrs.type === 'groupchat' && stanza.getChild('body')) {
         if(stanza.attrs.from in participants) {
           const nick = participants[stanza.attrs.from].name.replace(' ', '_');
           const message = stanza.getChild('body').text();


### PR DESCRIPTION
Prevent crash on receiving a poll message, that is a groupchat message without a body, e.g.:
```
IN
<message from="test-foo@conference.meet.w3c-ccg.org/d01fc1f7" type="groupchat" to="cel@meet.w3c-ccg.org/y4zn-zeg" xmlns="jabber:client"><json-message xmlns="http://jitsi.org/jitmeet">{"type":"answer-poll","pollId":"pgzwixh0gc","voterId":"d01fc1f7","voterName":"Charles Lehner (Spruce)","answers":[true,true]}</json-message></message>

<message from="test-foo@conference.meet.w3c-ccg.org/d01fc1f7" type="groupchat" to="cel@meet.w3c-ccg.org/y4zn-zeg">
  <json-message xmlns="http://jitsi.org/jitmeet">
    {"type":"answer-poll","pollId":"pgzwixh0gc","voterId":"d01fc1f7","voterName":"Charles Lehner (Spruce)","answers":[true,true]}
  </json-message>
</message>

uncaught exception:  TypeError: Cannot read properties of undefined (reading 'text')
    at Client.<anonymous> (/home/cel/src/cgbot/lib/manage.js:154:50)
    at Client.emit (node:events:390:28)
    at Client.emit (node:domain:475:12)
    at Client._onElement (/home/cel/src/cgbot/node_modules/@xmpp/connection/index.js:106:10)
    at Parser.emit (node:events:390:28)
    at Parser.emit (node:domain:475:12)
    at Parser.onEndElement (/home/cel/src/cgbot/node_modules/@xmpp/xml/lib/Parser.js:52:12)
    at SaxLtx.emit (node:events:390:28)
    at SaxLtx.emit (node:domain:475:12)
    at SaxLtx._handleTagOpening (/home/cel/src/cgbot/node_modules/ltx/lib/parsers/ltx.js:40:12)
```